### PR TITLE
Tasks as directories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 end_of_line = lf
-max_line_length=79
+max_line_length = 88
 
 [*.bat]
 indent_style = tab

--- a/qwikstart/cli/resolver.py
+++ b/qwikstart/cli/resolver.py
@@ -1,17 +1,19 @@
-#!/usr/bin/env python3
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 import yaml
 
+from ..exceptions import TaskLoaderError
 from ..parser import TaskDefinition, parse_task
 from ..tasks import Task
+
+QWIKSTART_TASK_DEFINITION_FILE = "qwikstart.yml"
 
 
 class YamlLoader:
     known_extensions = {".yaml", ".yml"}
 
-    def can_handle(self, file_path: Path) -> bool:
+    def can_load(self, file_path: Path) -> bool:
         return file_path.suffix in self.known_extensions
 
     def load(self, file_path: Path) -> Dict[str, Any]:
@@ -19,26 +21,27 @@ class YamlLoader:
             return yaml.safe_load(f)
 
 
-loaders_list = [YamlLoader()]
+class LocalPathResolver:
 
+    loader = YamlLoader()
 
-class ResolveLocalPath:
     def __init__(self, path: str, root: Optional[Path] = None):
         root = root or Path(".")
         self.resolved_path = root.joinpath(path).resolve()
+        if self.resolved_path.is_dir():
+            self.resolved_path = self.resolved_path / QWIKSTART_TASK_DEFINITION_FILE
 
     def exists(self) -> bool:
         return self.resolved_path.is_file()
 
     def parsed_data(self) -> Dict[str, Any]:
-        for loader in loaders_list:
-            if loader.can_handle(self.resolved_path):
-                return loader.load(self.resolved_path)
+        if self.loader.can_load(self.resolved_path):
+            return self.loader.load(self.resolved_path)
         else:
-            raise RuntimeError(f"No loader to handle {self.resolved_path!r}")
+            raise TaskLoaderError(f"Cannot load {self.resolved_path!r}")
 
 
-task_resolver_list = [ResolveLocalPath]
+task_resolver_list = [LocalPathResolver]
 
 
 def resolve_task(task_path: str) -> Task:
@@ -54,4 +57,4 @@ def resolve_task(task_path: str) -> Task:
             attempted_paths.append(resolver.resolved_path)
     else:
         attempts = "\n- ".join(str(path) for path in attempted_paths)
-        raise RuntimeError(f"Could not resolve path. Attempted: {attempts}")
+        raise TaskLoaderError(f"Could not resolve path. Attempted: {attempts}")

--- a/qwikstart/exceptions.py
+++ b/qwikstart/exceptions.py
@@ -1,0 +1,26 @@
+"""
+qwikstart.exceptions
+-----------------------
+
+All exceptions used in the qwikstart code base are defined here.
+"""
+
+
+class QwikstartException(Exception):
+    """Base exception class. All qwikstart-specific exceptions should subclass this."""
+
+
+class TaskLoaderError(QwikstartException):
+    """Exception raised when loading task definition fails."""
+
+
+class TaskParserError(QwikstartException):
+    """Exception raised when parsing task definition fails."""
+
+
+class OperationError(QwikstartException):
+    """Exception raised during execution of operation."""
+
+
+class OperationDefinitionError(QwikstartException):
+    """Exception raised when an operation is improperly defined."""

--- a/qwikstart/operations/__init__.py
+++ b/qwikstart/operations/__init__.py
@@ -1,10 +1,9 @@
 from . import add_file, add_file_tree, insert_text, prompt_user
-from .base import BaseOperation, GenericOperation, OperationError
+from .base import BaseOperation, GenericOperation
 
 __all__ = [
     "BaseOperation",
     "GenericOperation",
-    "OperationError",
     "add_file",
     "add_file_tree",
     "insert_text",

--- a/qwikstart/operations/base.py
+++ b/qwikstart/operations/base.py
@@ -3,22 +3,15 @@ from typing import Any, Dict, Generic, Mapping, Optional, TypeVar, cast
 
 from .. import utils
 from ..base_context import BaseContext, DictContext
+from ..exceptions import OperationDefinitionError
 
-__all__ = ["BaseOperation", "GenericOperation", "OperationError"]
+__all__ = ["BaseOperation", "GenericOperation"]
 
 
 ContextData = Optional[Mapping[str, Any]]
 ContextMapping = Optional[Mapping[str, str]]
 TContext = TypeVar("TContext", bound=BaseContext)
 TOutput = TypeVar("TOutput", bound=Optional[DictContext])
-
-
-class OperationError(RuntimeError):
-    pass
-
-
-class OperationDefinitionError(ValueError):
-    pass
 
 
 class BaseOperation(Generic[TContext, TOutput], abc.ABC):

--- a/qwikstart/operations/find_tagged_line.py
+++ b/qwikstart/operations/find_tagged_line.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing_extensions import TypedDict
 
 from ..base_context import BaseContext
-from .base import BaseOperation, OperationError
+from ..exceptions import OperationError
+from .base import BaseOperation
 
 __all__ = ["Context", "Operation", "Output"]
 

--- a/qwikstart/parser/__init__.py
+++ b/qwikstart/parser/__init__.py
@@ -1,10 +1,4 @@
-from .core import OperationMapping, ParserError, get_operations_mapping
+from .core import OperationMapping, get_operations_mapping
 from .tasks import TaskDefinition, parse_task
 
-__all__ = [
-    "OperationMapping",
-    "ParserError",
-    "TaskDefinition",
-    "get_operations_mapping",
-    "parse_task",
-]
+__all__ = ["OperationMapping", "TaskDefinition", "get_operations_mapping", "parse_task"]

--- a/qwikstart/parser/core.py
+++ b/qwikstart/parser/core.py
@@ -2,11 +2,6 @@ from typing import Dict, Type
 
 from ..operations import BaseOperation, GenericOperation
 
-
-class ParserError(RuntimeError):
-    pass
-
-
 OperationMapping = Dict[str, Type[GenericOperation]]
 
 

--- a/qwikstart/parser/operations.py
+++ b/qwikstart/parser/operations.py
@@ -2,8 +2,9 @@ import collections
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Type, Union
 
 from .. import utils
+from ..exceptions import TaskParserError
 from ..operations import GenericOperation
-from .core import OperationMapping, ParserError, get_operations_mapping
+from .core import OperationMapping, get_operations_mapping
 
 __all__ = ["OperationDefinition", "parse_operation"]
 
@@ -26,7 +27,7 @@ def parse_operation(
     op_def = normalize_op_definition(op_def)
 
     if op_def.name not in known_operations:
-        raise ParserError(f"Could not find operation named '{op_def.name}'")
+        raise TaskParserError(f"Could not find operation named '{op_def.name}'")
 
     operation_class = known_operations[op_def.name]
     return operation_class(**op_def.config)
@@ -42,7 +43,7 @@ def normalize_op_definition(
         return OperationDefinition(name=op_def, config={})
     elif isinstance(op_def, collections.abc.Mapping):
         if len(op_def) != 1:
-            raise ParserError(
+            raise TaskParserError(
                 "Operation definition with dict should only have a single key"
                 f", but given {op_def}"
             )
@@ -50,10 +51,10 @@ def normalize_op_definition(
         return OperationDefinition(name=op_name, config=op_def[op_name])
     elif isinstance(op_def, collections.abc.Sequence):
         if len(op_def) != 2:
-            raise ParserError(
+            raise TaskParserError(
                 "Operation definition with sequence should only have two items"
                 f", but given {op_def}"
             )
         return OperationDefinition(*op_def)
     else:
-        raise ParserError(f"Could not parse operation definition: {op_def}")
+        raise TaskParserError(f"Could not parse operation definition: {op_def}")

--- a/tests/cli/test_resolver.py
+++ b/tests/cli/test_resolver.py
@@ -4,12 +4,45 @@ from typing import Any, Callable, Dict, Iterator
 from unittest.mock import Mock, patch
 
 import pytest
+from pyfakefs.fake_filesystem_unittest import TestCase
 
 from qwikstart.cli import resolver
+from qwikstart.exceptions import TaskLoaderError
+
+
+class TestLocalPathResolver(TestCase):
+    def setUp(self) -> None:
+        self.setUpPyfakefs()
+
+    def test_resolve_file(self) -> None:
+        self.fs.create_file("/path/to/file.yml", contents='{"a": 1}')
+        res = resolver.LocalPathResolver("/path/to/file.yml")
+        assert res.exists()
+        assert res.parsed_data() == {"a": 1}
+
+    def test_resolve_directory(self) -> None:
+        self.fs.create_file("/path/containing/qwikstart.yml", contents='{"a": 1}')
+        res = resolver.LocalPathResolver("/path/containing/")
+        assert res.exists()
+        assert res.parsed_data() == {"a": 1}
+
+    def test_unknown_file_type(self) -> None:
+        self.fs.create_file("/path/to/file.txt", contents='{"a": 1}')
+        res = resolver.LocalPathResolver("/path/to/file.txt")
+        assert res.exists()
+        with pytest.raises(TaskLoaderError):
+            res.parsed_data()
 
 
 class TestResolveTask:
-    def test_resolved(self) -> None:
+    def test_resolve_file(self) -> None:
+        data = {"name": "fake_task"}
+        mock_resolver = create_mock_task_resolver(data)
+        with patch_resolve_task_dependencies(mock_resolver) as mocks:
+            resolver.resolve_task("fake.yml")
+        mocks.parse_task.assert_called_once_with(data, "fake.yml")
+
+    def test_resolve_directory(self) -> None:
         data = {"name": "fake_task"}
         mock_resolver = create_mock_task_resolver(data)
         with patch_resolve_task_dependencies(mock_resolver) as mocks:
@@ -19,7 +52,7 @@ class TestResolveTask:
     def test_not_found(self) -> None:
         mock_resolver = create_mock_task_resolver(data={}, file_exists=False)
         with patch_resolve_task_dependencies(mock_resolver) as mocks:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(TaskLoaderError):
                 resolver.resolve_task("fake.yml")
         mocks.parse_task.assert_not_called()
 

--- a/tests/operations/test_find_tagged_line.py
+++ b/tests/operations/test_find_tagged_line.py
@@ -1,7 +1,8 @@
 # Ignore pytest typing: see https://github.com/pytest-dev/pytest/issues/3342
 import pytest
 
-from qwikstart.operations import OperationError, find_tagged_line
+from qwikstart.exceptions import OperationError
+from qwikstart.operations import find_tagged_line
 
 from .. import helpers
 

--- a/tests/parser/test_operations.py
+++ b/tests/parser/test_operations.py
@@ -1,7 +1,7 @@
 # Ignore pytest typing: see https://github.com/pytest-dev/pytest/issues/3342
 import pytest
 
-from qwikstart import parser
+from qwikstart.exceptions import TaskParserError
 from qwikstart.operations import find_tagged_line, insert_text
 from qwikstart.parser import operations
 
@@ -34,5 +34,5 @@ class TestParseOperation:
         )
 
     def test_unknown_operation(self) -> None:
-        with pytest.raises(parser.ParserError):
+        with pytest.raises(TaskParserError):
             operations.parse_operation("undefined_operation")


### PR DESCRIPTION
- Allow tasks to be defined as directories containing a `qwikstart.yml`
- Move exceptions to `qwikstart.exceptions`
- Update `.editorconfig` to match black/flake8 config