### PR TITLE
Remove two-way mapping parameter to BaseOperation

### DIFF
--- a/examples/hello_world.yml
+++ b/examples/hello_world.yml
@@ -11,3 +11,6 @@ operations:
                 Hello {{ qwikstart.name }}!
 
                 {{ 'Welcome to the qwikstart tool!' | colored("yellow") }}
+
+                Please visit the documentation to learn more:
+                    https://qwikstart.readthedocs.io/en/latest/

--- a/qwikstart/operations/base.py
+++ b/qwikstart/operations/base.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Generic, Mapping, Optional, TypeVar, cast
 
 from .. import utils
 from ..base_context import BaseContext, DictContext
-from ..exceptions import OperationDefinitionError
 
 __all__ = ["BaseOperation", "GenericOperation"]
 
@@ -22,18 +21,10 @@ class BaseOperation(Generic[TContext, TOutput], abc.ABC):
     def __init__(
         self,
         local_context: ContextData = None,
-        mapping: ContextMapping = None,
         input_mapping: ContextMapping = None,
         output_mapping: ContextMapping = None,
     ):
         self.local_context = local_context or {}
-
-        if mapping and (input_mapping or output_mapping):
-            msg = "`mapping` cannot be specified with input or output mappings"
-            raise OperationDefinitionError(msg)
-        if mapping:
-            input_mapping = mapping
-            output_mapping = {value: key for key, value in mapping.items()}
         self.input_mapping = input_mapping or {}
         self.output_mapping = output_mapping or {}
 

--- a/tests/operations/test_base.py
+++ b/tests/operations/test_base.py
@@ -1,11 +1,8 @@
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 from unittest import TestCase
 
-import pytest
-
 from qwikstart.base_context import BaseContext, DictContext
-from qwikstart.exceptions import OperationDefinitionError
 from qwikstart.operations.base import BaseOperation
 
 from .. import helpers
@@ -52,19 +49,6 @@ class TestOperationHavingContextWithDict(TestCase):
         assert operation.run_context.template_variables == template_variables
         assert output["template_variables"] == template_variables
 
-    def test_mapping_temporarily_remaps_key_during_execution(self) -> None:
-        operation = FakeOperation(mapping={"vars": "template_variables"})
-        template_variables = {"some": "value"}
-        output = operation.execute(
-            {"execution_context": self.execution_context, "vars": template_variables}
-        )
-        # FIXME: Remove cast: mypy appears to think `operation.run_context` is `None`.
-        run_context = cast(ContextWithDict, operation.run_context)
-        # During exection, `vars` is remapped to `template_variables`:
-        assert run_context.template_variables == template_variables
-        # On return, `template_variables` is remapped back to `vars`:
-        assert output["vars"] == template_variables
-
     def test_input_mapping(self) -> None:
         operation = FakeOperation(input_mapping={"vars": "template_variables"})
         output = operation.execute(
@@ -81,16 +65,6 @@ class TestOperationHavingContextWithDict(TestCase):
             }
         )
         assert output["output_vars"] == {"some": "value"}
-
-    def test_mapping_and_input_mapping_cannot_both_be_defined(self) -> None:
-        mapping = {"vars": "template_variables"}
-        with pytest.raises(OperationDefinitionError):
-            FakeOperation(mapping=mapping, input_mapping=mapping)
-
-    def test_mapping_and_output_mapping_cannot_both_be_defined(self) -> None:
-        mapping = {"vars": "template_variables"}
-        with pytest.raises(OperationDefinitionError):
-            FakeOperation(mapping=mapping, output_mapping=mapping)
 
     def test_local_context_takes_precedence(self) -> None:
         operation = FakeOperation(

--- a/tests/operations/test_insert_text.py
+++ b/tests/operations/test_insert_text.py
@@ -53,8 +53,10 @@ class TestTextInject:
                 """
             ),
         }
-        mapping = {"line_number": "line"}
-        assert insert_text_and_return_file_text(context, mapping=mapping) == dedent(
+        input_mapping = {"line_number": "line"}
+        assert insert_text_and_return_file_text(
+            context, input_mapping=input_mapping
+        ) == dedent(
             """
                 A
                 New Line

--- a/tests/parser/test_operations.py
+++ b/tests/parser/test_operations.py
@@ -13,10 +13,12 @@ class TestParseOperation:
         )
 
     def test_dict_definition(self) -> None:
-        mapping = {"line_number": "line"}
-        op_def: operations.UnparsedOperation = {"insert_text": {"mapping": mapping}}
+        input_mapping = {"line_number": "line"}
+        op_def: operations.UnparsedOperation = {
+            "insert_text": {"input_mapping": input_mapping}
+        }
         assert operations.parse_operation(op_def) == insert_text.Operation(
-            mapping=mapping
+            input_mapping=input_mapping
         )
 
     def test_tuple_definition(self) -> None:

--- a/tests/parser/test_tasks.py
+++ b/tests/parser/test_tasks.py
@@ -7,21 +7,21 @@ from qwikstart.tasks import Task
 
 class TestParseTask:
     def test_operation_list(self) -> None:
-        mapping = {"line_number": "line"}
+        input_mapping = {"line_number": "line"}
         task_definition: parser.TaskDefinition = {
-            "operations": [{"insert_text": {"mapping": mapping}}]
+            "operations": [{"insert_text": {"input_mapping": input_mapping}}]
         }
         assert parser.parse_task(task_definition) == Task(
             context={"execution_context": mock.ANY},
-            operations=[insert_text.Operation(mapping=mapping)],
+            operations=[insert_text.Operation(input_mapping=input_mapping)],
         )
 
     def test_operation_dict(self) -> None:
-        mapping = {"line_number": "line"}
+        input_mapping = {"line_number": "line"}
         task_definition: parser.TaskDefinition = {
-            "operations": {"insert_text": {"mapping": mapping}}
+            "operations": {"insert_text": {"input_mapping": input_mapping}}
         }
         assert parser.parse_task(task_definition) == Task(
             context={"execution_context": mock.ANY},
-            operations=[insert_text.Operation(mapping=mapping)],
+            operations=[insert_text.Operation(input_mapping=input_mapping)],
         )


### PR DESCRIPTION
... in favor of `input_mapping` and `output_mapping` parameters.

Closes #30