### PR TITLE
Remove functionality marked obsolete in v0.8

### DIFF
--- a/examples/hello_world/qwikstart.yml
+++ b/examples/hello_world/qwikstart.yml
@@ -1,8 +1,8 @@
 steps:
     "Write hello-world file to disk":
-        name: add_file
-        template_path: "../templates/hello_world.txt"
+        name: echo
         template_variables:
             name: "World"
         template_variable_prefix: null
-        target_path: "./examples/output/hello_world.txt"
+        message: |
+            Hello, {{ name }}!

--- a/examples/templates/hello_world.txt
+++ b/examples/templates/hello_world.txt
@@ -1,1 +1,1 @@
-Hello, {{ name }}!
+Hello, {{ qwikstart.name }}!

--- a/qwikstart/exceptions.py
+++ b/qwikstart/exceptions.py
@@ -27,6 +27,10 @@ class ConfigurationError(UserFacingError):
     """User-facing exception raised during qwikstart configuration."""
 
 
+class ObsoleteError(UserFacingError):
+    """User-facing exception raised for obsolete functionality."""
+
+
 class OperationError(UserFacingError):
     """User-facing exception raised during execution of operation."""
 

--- a/qwikstart/parser/operations.py
+++ b/qwikstart/parser/operations.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, NamedTuple, Optional, Type, cast
 
 from .. import utils
-from ..exceptions import TaskParserError
+from ..exceptions import ObsoleteError, TaskParserError
 from ..operations import BaseOperation, GenericOperation
 from ..repository import OperationSpec
 from ..utils.io import dump_yaml_string
@@ -21,9 +21,9 @@ RESERVED_WORDS_OPERATION_CONFIG = {
 }
 
 
-MAPPING_DEPRECATION_WARNING = (
-    "`{0}` as a top-level config in task specifications is deprecated and will be "
-    "removed in v0.8. Use `opconfig.{0}` instead."
+MAPPING_OBSOLETE_ERROR = (
+    "Support for `{0}` as a top-level config in task definitions was removed in v0.8. "
+    "Use `opconfig.{0}` instead."
 )
 
 
@@ -58,18 +58,12 @@ class OperationDefinition(NamedTuple):
         `local_context` passed to the operation initializer.
         """
         description = self.config.get("description", "")
-
-        input_mapping = self.config.get("input_mapping")
-        output_mapping = self.config.get("output_mapping")
         opconfig = self.config.get("opconfig", {})
-        if input_mapping:
-            # FIXME: Raise error in v0.8
-            logger.info(MAPPING_DEPRECATION_WARNING.format("input_mapping"))
-            opconfig["input_mapping"] = input_mapping
-        if output_mapping:
-            # FIXME: Raise error in v0.8
-            logger.info(MAPPING_DEPRECATION_WARNING.format("output_mapping"))
-            opconfig["output_mapping"] = output_mapping
+
+        if "input_mapping" in self.config:
+            raise ObsoleteError(MAPPING_OBSOLETE_ERROR.format("input_mapping"))
+        if "output_mapping" in self.config:
+            raise ObsoleteError(MAPPING_OBSOLETE_ERROR.format("output_mapping"))
 
         local_context = self.config.get("local_context", {})
         local_context.update(

--- a/qwikstart/parser/tasks.py
+++ b/qwikstart/parser/tasks.py
@@ -1,17 +1,12 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from .. import base_context
-from ..exceptions import TaskParserError
+from ..exceptions import ObsoleteError, TaskParserError
 from ..operations import BaseOperation
-from ..repository import OperationsList
 from ..tasks import Task
-from .operations import (
-    get_operations_mapping,
-    parse_operation,
-    parse_operation_from_step,
-)
+from .operations import get_operations_mapping, parse_operation_from_step
 
 logger = logging.getLogger(__name__)
 
@@ -21,9 +16,9 @@ steps:
         name: echo
         message: "Hello, World!"
 """
-OPERATIONS_DEPRECATION_WARNING = (
-    "Note that `operations` in task specification is deprecated and will be "
-    "removed in v0.8. Use `steps` instead."
+OPERATIONS_OBSOLETE_ERROR = (
+    "Support for `operations` in task definition was removed in v0.8. "
+    "Use `steps` instead."
 )
 
 
@@ -37,39 +32,20 @@ def parse_task(
 
 
 def parse_task_steps(task_spec: Dict[str, Any]) -> Sequence[BaseOperation[Any, Any]]:
+    if "operations" in task_spec:
+        raise ObsoleteError(OPERATIONS_OBSOLETE_ERROR)
+
+    if "steps" not in task_spec:
+        raise TaskParserError(
+            "Task specification file should define `steps` dictionary, e.g.:\n"
+            + EXAMPLE_TASK_DEFINITION
+        )
+
     known_operations = get_operations_mapping()
-
-    if task_spec.get("steps"):
-        if task_spec.get("operations"):
-            logger.warning(
-                "Found both `steps` and `operations` in task specification. "
-                "Only `steps` will be read."
-            )
-        return [
-            parse_operation_from_step(
-                {"description": op_desc, **op_def}, known_operations
-            )
-            for op_desc, op_def in task_spec["steps"].items()
-        ]
-    elif task_spec.get("operations"):
-        # FIXME: Raise error in v0.8
-        logger.info(OPERATIONS_DEPRECATION_WARNING)
-        return [
-            parse_operation(op_def, known_operations)
-            for op_def in normalize_operations_list(task_spec["operations"])
-        ]
-
-    raise TaskParserError(
-        "Task specification file should define `steps` dictionary, e.g.:\n"
-        + EXAMPLE_TASK_DEFINITION
-    )
-
-
-def normalize_operations_list(operations_list: OperationsList) -> List[Dict[str, Any]]:
-    """"""
-    if isinstance(operations_list, list):
-        return operations_list  # type: ignore
-    return [{op_name: op_config} for op_name, op_config in operations_list.items()]
+    return [
+        parse_operation_from_step({"description": op_desc, **op_def}, known_operations)
+        for op_desc, op_def in task_spec["steps"].items()
+    ]
 
 
 def _initialize_context(

--- a/qwikstart/utils/prompt.py
+++ b/qwikstart/utils/prompt.py
@@ -7,15 +7,15 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type
 
 from qwikstart import utils
-from qwikstart.exceptions import UserFacingError
+from qwikstart.exceptions import ObsoleteError, UserFacingError
 
 from . import input_types
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_VALUE_DEPRECATION_WARNING = (
-    "Note that `default_value` in prompt inputs is deprecated and will be "
-    "removed in v0.8. Use `default` instead."
+DEFAULT_VALUE_OBSOLETE_ERROR = (
+    "Support for `default_value` in prompt inputs was removed in v0.8."
+    "Use `default` instead."
 )
 
 
@@ -42,9 +42,7 @@ def create_prompt_spec(**prompt_kwargs: Any) -> PromptSpec:
     This raises a UserFacingError if the PromptSpec is incorrectly defined.
     """
     if "default_value" in prompt_kwargs:
-        # FIXME: Raise error in v0.8
-        logger.warning(DEFAULT_VALUE_DEPRECATION_WARNING)
-        prompt_kwargs["default"] = prompt_kwargs.pop("default_value")
+        raise ObsoleteError(DEFAULT_VALUE_OBSOLETE_ERROR)
 
     name = prompt_kwargs.get("name")
     if not name:

--- a/tests/parser/test_operations.py
+++ b/tests/parser/test_operations.py
@@ -1,12 +1,11 @@
-from typing import Any, Dict, List, Tuple
+from typing import List
 from unittest.mock import Mock, patch
 
 import pytest
 
 from qwikstart.exceptions import ObsoleteError, TaskParserError
-from qwikstart.operations import find_tagged_line, insert_text
+from qwikstart.operations import insert_text
 from qwikstart.parser import operations
-from qwikstart.repository import OperationSpec
 
 from .. import helpers
 
@@ -96,77 +95,3 @@ class TestParseOperationFromStep:
         op_def = {"name": "fake_op", "description": "Test", "output_mapping": {}}
         with pytest.raises(ObsoleteError):
             operations.parse_operation_from_step(op_def)
-
-
-class TestParseOperation:
-    def test_string_definition(self) -> None:
-        assert (
-            operations.parse_operation("find_tagged_line")
-            == find_tagged_line.Operation()
-        )
-
-    def test_dict_definition(self) -> None:
-        op_def: OperationSpec = {"insert_text": {"description": "Test operation"}}
-        assert operations.parse_operation(op_def) == insert_text.Operation(
-            description="Test operation"
-        )
-
-    def test_tuple_definition(self) -> None:
-        op_def: OperationSpec = ("insert_text", {})
-        assert operations.parse_operation(op_def) == insert_text.Operation()
-
-    def test_operation_with_local_context(self) -> None:
-        context = {"line": 42}
-        op_def: OperationSpec = {"insert_text": {"local_context": context}}
-        assert operations.parse_operation(op_def) == insert_text.Operation(
-            local_context=context
-        )
-
-    def test_operation_with_context_defined_as_top_level_parameter(self) -> None:
-        context = {"line": 42}
-        op_def: OperationSpec = {"insert_text": context}
-        assert operations.parse_operation(op_def) == insert_text.Operation(
-            local_context=context
-        )
-
-    def test_unknown_operation(self) -> None:
-        with pytest.raises(TaskParserError):
-            operations.parse_operation("undefined_operation")
-
-
-class TestNormalizeOpDefinition:
-    def test_empty_dict_not_supported(self) -> None:
-        error_msg = "Operation definition with dict should only have a single key"
-        with pytest.raises(TaskParserError, match=error_msg):
-            operations.normalize_op_definition({})
-
-    def test_dict_with_multiple_keys_not_supported(self) -> None:
-        op_def_with_too_many_keys: Dict[str, Any] = {"op1": {}, "op2": {}}
-        error_msg = "Operation definition with dict should only have a single key"
-        with pytest.raises(TaskParserError, match=error_msg):
-            operations.normalize_op_definition(op_def_with_too_many_keys)
-
-    def test_tuple_of_one_not_supported(self) -> None:
-        op_def_with_only_a_name = tuple(["name-of-op"])
-        error_msg = "Operation definition with sequence should only have two items"
-        with pytest.raises(TaskParserError, match=error_msg):
-            # Ignore typing since we're intentionally passing an incompatible tuple
-            operations.normalize_op_definition(op_def_with_only_a_name)  # type: ignore
-
-    def test_tuple_of_more_than_two_not_supported(self) -> None:
-        op_def_with_bad_tuple: Tuple[str, Dict[str, Any], str] = (
-            "name-of-op",
-            {},
-            "unsupported-third-argument",
-        )
-        error_msg = "Operation definition with sequence should only have two items"
-        with pytest.raises(TaskParserError, match=error_msg):
-            # Ignore typing since we're intentionally passing an incompatible tuple
-            operations.normalize_op_definition(op_def_with_bad_tuple)  # type: ignore
-
-    def test_invalid_op_def_type(self) -> None:
-        invalid_op_def_type = True
-        error_msg = "Could not parse operation definition: True"
-        with pytest.raises(TaskParserError, match=error_msg):
-            # Ignore typing since we're intentionally passing an incompatible tuple
-            operations.normalize_op_definition(invalid_op_def_type)  # type: ignore

--- a/tests/parser/test_operations.py
+++ b/tests/parser/test_operations.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from qwikstart.exceptions import TaskParserError
+from qwikstart.exceptions import ObsoleteError, TaskParserError
 from qwikstart.operations import find_tagged_line, insert_text
 from qwikstart.parser import operations
 from qwikstart.repository import OperationSpec
@@ -87,29 +87,15 @@ class TestParseOperationFromStep:
         assert op == helpers.FakeOperation(description="Test", opconfig=opconfig)
         logger.info.assert_not_called()
 
-    @patch.object(operations, "logger")
-    def test_old_input_mapping_logs_deprecation(self, logger: Mock) -> None:
-        mapping = {"name": "template_variables.name"}
-        op_def = {"name": "fake_op", "description": "Test", "input_mapping": mapping}
-        op = operations.parse_operation_from_step(op_def)
+    def test_old_input_mapping_raises_error(self) -> None:
+        op_def = {"name": "fake_op", "description": "Test", "input_mapping": {}}
+        with pytest.raises(ObsoleteError):
+            operations.parse_operation_from_step(op_def)
 
-        opconfig = dict(input_mapping=mapping)
-        assert op == helpers.FakeOperation(description="Test", opconfig=opconfig)
-        logger.info.assert_called_once_with(
-            operations.MAPPING_DEPRECATION_WARNING.format("input_mapping")
-        )
-
-    @patch.object(operations, "logger")
-    def test_old_output_mapping_logs_deprecation(self, logger: Mock) -> None:
-        mapping = {"template_variables.name": "name"}
-        op_def = {"name": "fake_op", "description": "Test", "output_mapping": mapping}
-        op = operations.parse_operation_from_step(op_def)
-
-        opconfig = dict(output_mapping=mapping)
-        assert op == helpers.FakeOperation(description="Test", opconfig=opconfig)
-        logger.info.assert_called_once_with(
-            operations.MAPPING_DEPRECATION_WARNING.format("output_mapping")
-        )
+    def test_old_output_mapping_raises_error(self) -> None:
+        op_def = {"name": "fake_op", "description": "Test", "output_mapping": {}}
+        with pytest.raises(ObsoleteError):
+            operations.parse_operation_from_step(op_def)
 
 
 class TestParseOperation:

--- a/tests/parser/test_tasks.py
+++ b/tests/parser/test_tasks.py
@@ -1,55 +1,33 @@
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY
 
 import pytest
 
-from qwikstart.exceptions import TaskParserError
+from qwikstart.exceptions import ObsoleteError, TaskParserError
 from qwikstart.operations import insert_text
 from qwikstart.parser import tasks
 from qwikstart.tasks import Task
 
 
 class TestParseTask:
-    def test_operation_list(self) -> None:
-        task_spec = {"operations": [{"insert_text": {"description": "Test operation"}}]}
-        assert tasks.parse_task(task_spec) == Task(
-            context={"execution_context": ANY},
-            operations=[insert_text.Operation(description="Test operation")],
-        )
-
-    def test_operation_dict(self) -> None:
-        task_spec = {"operations": {"insert_text": {"description": "Test operation"}}}
-        assert tasks.parse_task(task_spec) == Task(
-            context={"execution_context": ANY},
-            operations=[insert_text.Operation(description="Test operation")],
-        )
-
-    @patch.object(tasks, "logger")
-    def test_deprecation_logged_for_operations(self, logger: Mock) -> None:
-        tasks.parse_task({"operations": {"insert_text": {}}})
-        logger.info.assert_called_once_with(tasks.OPERATIONS_DEPRECATION_WARNING)
-
-    def test_steps(self) -> None:
+    def test_parse_returns_task_instance(self) -> None:
         task_spec = {"steps": {"Step 1": {"name": "insert_text"}}}
         expected_operation = insert_text.Operation(description="Step 1")
         assert tasks.parse_task(task_spec) == Task(
             context={"execution_context": ANY}, operations=[expected_operation]
         )
 
-    @patch.object(tasks, "logger")
-    def test_both_steps_and_operations_defined(self, logger: Mock) -> None:
+    def test_operations_key_raises_obsolete_error(self) -> None:
+        with pytest.raises(ObsoleteError):
+            tasks.parse_task({"operations": {"insert_text": {}}})
+
+    def test_both_steps_and_operations_defined_raises_error(self) -> None:
         task_spec = {
             "steps": {"Step 1": {"name": "insert_text"}},
             "operations": {"completely_ignored": {}},
         }
-        assert tasks.parse_task(task_spec) == Task(
-            context={"execution_context": ANY},
-            operations=[insert_text.Operation(description="Step 1")],
-        )
-        logger.warning.assert_called_once_with(
-            "Found both `steps` and `operations` in task specification. "
-            "Only `steps` will be read."
-        )
+        with pytest.raises(ObsoleteError):
+            tasks.parse_task(task_spec)
 
-    def test_exception_when_neither_steps_or_operations_defined(self) -> None:
+    def test_steps_not_defined_raises_error(self) -> None:
         with pytest.raises(TaskParserError):
             tasks.parse_task({})

--- a/tests/utils/test_prompt.py
+++ b/tests/utils/test_prompt.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 
 from qwikstart import utils
-from qwikstart.exceptions import UserFacingError
+from qwikstart.exceptions import ObsoleteError, UserFacingError
 from qwikstart.utils import prompt as _prompt
 from qwikstart.utils.input_types import BoolInput, InputType, IntegerInput, StringInput
 
@@ -23,14 +23,9 @@ class TestCreatePromptSpec:
         assert prompt_spec.name == "test"
         assert prompt_spec.default == "hello"
 
-    @patch.object(_prompt, "logger")
-    def test_deprecated_default_value_still_works(self, logger: Mock) -> None:
-        prompt_spec = _prompt.create_prompt_spec(name="test", default_value="hello")
-        assert prompt_spec.name == "test"
-        assert prompt_spec.default == "hello"
-        logger.warning.assert_called_once_with(
-            _prompt.DEFAULT_VALUE_DEPRECATION_WARNING
-        )
+    def test_deprecated_default_value_raises_error(self) -> None:
+        with pytest.raises(ObsoleteError):
+            _prompt.create_prompt_spec(name="test", default_value="hello")
 
     def test_name_missing_raises(self) -> None:
         msg = "PromptSpec definition has no 'name'"


### PR DESCRIPTION
Removes the following:
- `operations` key in task definition
- `input_mapping` and `output_mapping` in operation definitions
- `default_value` in prompt inputs